### PR TITLE
Fix #51

### DIFF
--- a/connmgr.py
+++ b/connmgr.py
@@ -625,28 +625,14 @@ This involves loss of information, it is recommended to revert it.")
         lines = [line.strip() for line in file(SSH_CONFIG_FILE)]
         comments_removed = [remove_comment(line) for line in lines]
         blanks_removed = [line for line in comments_removed if line]
+        non_hosts_removed = [line for line in blanks_removed if a_host(line)]
 
-        block = itertools.groupby(blanks_removed, not_a_host)
-
-        first_block = False
-        for key, group in block:
-            Info = dict([line.split(None, 1) for line in group])
-
-            if (not key):
-                if (not first_block):
-                                        first_block = True
-                importedHost = Info['Host']
-            if (key and first_block):
-                if 'HostName' in Info:
-                                        importedHostname = Info['HostName']
-                if 'User' in Info:
-                                        importedHostname = Info['User']+'@'+importedHostname
-                if 'Port' in Info:
-                                        importedHostname = '-p '+Info['Port']+' '+importedHostname
-
+        for line in non_hosts_removed:
+            importedHosts = line.split(None)[1:]
+            for importedHost in importedHosts:
                 if importedHost != '*':
                     treestore.append(import_iter, ['__item__',
-                        importedHost, importedHostname, 'Unnamed', 'ssh'])
+                        importedHost, importedHost, 'Unnamed', 'ssh'])
 
     def is_folder(self, iter):
         if self.treestore.get_value(iter, 0) == '__folder__':


### PR DESCRIPTION
Fixed .ssh/config parsing but replaces it by a simpler algorithm, ignoring HostName, User, Port (and IdentityFile, which is already ignored)